### PR TITLE
Fix empty test description in case of multiline __doc__

### DIFF
--- a/colour_runner/result.py
+++ b/colour_runner/result.py
@@ -62,7 +62,7 @@ class ColourTextTestResult(result.TestResult):
         test_class = test.__class__
         doc = test_class.__doc__
         if self.descriptions and doc:
-            return doc.split('\n')[0].strip()
+            return doc.strip().split('\n')[0].strip()
         return strclass(test_class)
 
     def startTest(self, test):


### PR DESCRIPTION
We often use multiline class level doc-comments:
```python
class TestCalc(TestCase):
    """
    Test calc module.
    """
    ...
```
In this case getClassDescription would return first empty line of the comment and test cases would be displayed without title.