### PR TITLE
Don't require `no_color` on `ColourRunnerMixin`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change log for `colour-runner`
 
+## 0.1.1 [Unreleased]
+
+- FIXED: The `no_color` shouldn't be required when using `ColourRunnerMixin`.
+
 ## 0.1.0
 
 - ADDED: Support for disabling coloured output without uninstalling.

--- a/colour_runner/django_runner.py
+++ b/colour_runner/django_runner.py
@@ -5,7 +5,7 @@ class ColourRunnerMixin(object):
     test_runner = ColourTextTestRunner
 
     def __init__(self, *args, **kwargs):
-        self.no_colour = kwargs['no_color']
+        self.no_colour = kwargs.get('no_color', False)
         super(ColourRunnerMixin, self).__init__(*args, **kwargs)
 
     def run_suite(self, suite, **kwargs):


### PR DESCRIPTION
When upgrading to v0.1.0, users were forced to add the new argument.

(eg: https://github.com/incuna/django-pgcrypto-fields/pull/54/commits/6b15877b29963a895c56297c4f63017a64d5de48)

This should ensure that the argument is not required.

Once we drop support for python 2 we can make this a keyword-only argument.